### PR TITLE
FIX-GOPROXY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang
+FROM public.ecr.aws/bitnami/golang:latest
 
 RUN apt update; apt install -y make git curl bash jq awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.21.1-alpine3.18
 
-RUN apk update; apk add make git curl bash jq awscli
+RUN apk update; apk add make git curl bash jq aws-cli
 
 #COPY ./go.env /custom_go.env
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM public.ecr.aws/bitnami/golang:1.21.1
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
+RUN touch $(go env GOROOT)/go.env && echo 'GOPROXY=https://proxy.golang.org,direct' > $(go env GOROOT)/go.env
+
 RUN go env
 RUN cat $(go env GOROOT)/go.env
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:1.21.1
+FROM public.ecr.aws/bitnami/golang
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
@@ -7,9 +7,6 @@ COPY ./go.env /custom_go.env
 RUN touch $(go env GOROOT)/go.env &&  \
     cat /custom_go.env >> $(go env GOROOT)/go.env &&  \
     rm /custom_go.env
-
-RUN go env
-RUN cat $(go env GOROOT)/go.env
 
 RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.10.0
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM golang:1.21.1-alpine3.18
 
-RUN apt update; apt install -y make git curl bash jq awscli
+RUN apk update; apk add make git curl bash jq awscli
 
 #COPY ./go.env /custom_go.env
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/bitnami/golang:latest
+FROM public.ecr.aws/bitnami/golang:1.21.1
 
 RUN apt update; apt install -y make git curl bash jq awscli
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM public.ecr.aws/bitnami/golang:latest
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
+RUN cat $(go env GOROOT)/go.env
+
 RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.10.0
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM public.ecr.aws/bitnami/golang:1.21.1
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
+RUN go env
 RUN cat $(go env GOROOT)/go.env
 
 RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.10.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,6 @@ FROM golang:1.21.1-alpine3.18
 
 RUN apk update; apk add make git curl bash jq aws-cli
 
-#COPY ./go.env /custom_go.env
-#
-#RUN touch $(go env GOROOT)/go.env &&  \
-#    cat /custom_go.env >> $(go env GOROOT)/go.env &&  \
-#    rm /custom_go.env
-
 RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.10.0
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM public.ecr.aws/bitnami/golang:1.21.1
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
-RUN touch $(go env GOROOT)/go.env && echo 'GOPROXY=https://proxy.golang.org,direct' > $(go env GOROOT)/go.env
+COPY ./go.env /custom_go.env
+
+RUN touch $(go env GOROOT)/go.env &&  \
+    cat /custom_go.env >> $(go env GOROOT)/go.env &&  \
+    rm /custom_go.env
 
 RUN go env
 RUN cat $(go env GOROOT)/go.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM public.ecr.aws/bitnami/golang
+FROM golang:1.21.1-alpine3.18
 
 RUN apt update; apt install -y make git curl bash jq awscli
 
-COPY ./go.env /custom_go.env
-
-RUN touch $(go env GOROOT)/go.env &&  \
-    cat /custom_go.env >> $(go env GOROOT)/go.env &&  \
-    rm /custom_go.env
+#COPY ./go.env /custom_go.env
+#
+#RUN touch $(go env GOROOT)/go.env &&  \
+#    cat /custom_go.env >> $(go env GOROOT)/go.env &&  \
+#    rm /custom_go.env
 
 RUN go install github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2@v2.10.0
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.28.0

--- a/go.env
+++ b/go.env
@@ -1,0 +1,12 @@
+# This file contains the initial defaults for go command configuration.
+# Values set by 'go env -w' and written to the user's go/env file override these.
+# The environment overrides everything else.
+
+# Use the Go module mirror and checksum database by default.
+# See https://proxy.golang.org for details.
+GOPROXY=https://proxy.golang.org,direct
+GOSUMDB=sum.golang.org
+
+# Automatically download newer toolchains as directed by go.mod files.
+# See https://go.dev/doc/toolchain for details.
+GOTOOLCHAIN=auto

--- a/go.env
+++ b/go.env
@@ -1,7 +1,3 @@
-# This file contains the initial defaults for go command configuration.
-# Values set by 'go env -w' and written to the user's go/env file override these.
-# The environment overrides everything else.
-
 # Use the Go module mirror and checksum database by default.
 # See https://proxy.golang.org for details.
 GOPROXY=https://proxy.golang.org,direct

--- a/go.env
+++ b/go.env
@@ -1,8 +1,0 @@
-# Use the Go module mirror and checksum database by default.
-# See https://proxy.golang.org for details.
-GOPROXY=https://proxy.golang.org,direct
-GOSUMDB=sum.golang.org
-
-# Automatically download newer toolchains as directed by go.mod files.
-# See https://go.dev/doc/toolchain for details.
-GOTOOLCHAIN=auto


### PR DESCRIPTION
fix the GOPROXY being searched in GOROOT/go.env file for recent go upgrades.

[go install fails when GOPROXY is empty](https://github.com/golang/go/issues/62274)

https://github.com/golang/go/issues/62274#issuecomment-1692504981