### PR TITLE
Adds buf.build/googleapis/googleapis in buf dep

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -4,6 +4,7 @@ deps:
 #  - buf.build/beta/googleapis
   - buf.build/grpc-ecosystem/grpc-gateway
   - buf.build/razorpay/googleapis-pubsub
+  - buf.build/googleapis/googleapis
 build:
   roots:
     - proto

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ echo "cloning protobuf files"
 bash sparse-checkout.sh
 
 echo "generating swagger docs"
-buf mod update && buf generate
+buf mod update && buf generate buf.build/googleapis/googleapis && buf generate
 
 echo "combining swagger docs into 1 file"
 bash combine_swagger_docs.sh docs


### PR DESCRIPTION
Description:

For RPCs leveraging steaming, `error` block is auto generated by swagger. Currently since we are not mapping the `buf.build/googleapis/googleapis` dependency, swagger file is failing to generate with error `Unknown reference:
#/definitions/google.rpc.Status:337:27` 

This PR adds `buf.build/googleapis/googleapis` as a dependency to fix this

